### PR TITLE
Allow editing artist

### DIFF
--- a/lib/karaoke/party/song.ex
+++ b/lib/karaoke/party/song.ex
@@ -17,7 +17,7 @@ defmodule Karaoke.Party.Song do
 
   def changeset(song, attrs) do
     song
-    |> cast(attrs, [:title, :singer])
+    |> cast(attrs, [:title, :singer, :artist])
     |> validate_required([:title, :singer])
   end
 

--- a/lib/karaoke_web/live/song_live/queued_song.ex
+++ b/lib/karaoke_web/live/song_live/queued_song.ex
@@ -11,10 +11,11 @@ defmodule KaraokeWeb.QueuedSongLive do
       <div id={@song.id} class="w-full py-4">
 
       <%!-- Edit Song Form (if editing) --%>
-      <.form :if={assigns.editing} id={"edit-queued-" <> @song.id} for={@form}  phx-target={@myself} phx-submit="save" class="edit-queued w-full grid sm:grid-cols-3 items-center gap-2" >
+      <.form :if={assigns.editing} id={"edit-queued-" <> @song.id} for={@form}  phx-target={@myself} phx-submit="save" class="edit-queued w-full grid sm:grid-cols-4 items-center gap-2" >
           <%!-- <span>{@song.id}</span> --%>
-          <.input field={@form[:singer]} id={@song.id <> "-singer"} type="text" />
-          <.input field={@form[:title]} id={@song.id <> "-title"} type="text" placeholder="song title"   />
+          <.input field={@form[:singer]} id={@song.id <> "-singer"} type="text" placeholder="performer name" />
+          <.input field={@form[:title]} id={@song.id <> "-title"} type="text" placeholder="song title" />
+          <.input field={@form[:artist]} id={@song.id <> "-artist"} type="text" placeholder="song artist" />
           <div class="grid xs:grid-cols-2 gap-2 mb-2">
           <.button type="submit" variant="primary">
             <.icon name="hero-check" />
@@ -29,9 +30,10 @@ defmodule KaraokeWeb.QueuedSongLive do
 
       <%!-- Song Info + Actions (if not editing) --%>
       <div :if={!assigns.editing} id={"view-queued-" <> @song.id}
-        class="view-queued w-full grid sm:grid-cols-3 gap-2">
+        class="view-queued w-full grid sm:grid-cols-4 gap-2">
           <span class="text-xl uppercase neon-text">{@song.singer} </span>
           <span class="text-lg">{@song.title}</span>
+          <span :if={@song.artist} class="text-lg">{@song.artist}</span>
 
         <div class="grid xs:grid-cols-2 gap-2 mb-2">
           <.button variant="primary" phx-click="edit" phx-target={@myself}>
@@ -56,7 +58,7 @@ defmodule KaraokeWeb.QueuedSongLive do
   def handle_event("edit", _params, socket) do
     song = socket.assigns.song
     {:noreply, socket
-      |> assign(form: to_form(%{"title" => song.title, "singer" => song.singer, "id" => song.id}, action: :save ))
+      |> assign(form: to_form(%{"title" => song.title, "singer" => song.singer, "artist" => song.artist, "id" => song.id}, action: :save ))
       |> assign(editing: true)
     }
   end

--- a/test/karaoke_web/live/party_live_test.exs
+++ b/test/karaoke_web/live/party_live_test.exs
@@ -5,8 +5,8 @@ defmodule KaraokeWeb.PartyLiveTest do
   import Phoenix.LiveViewTest
   import Karaoke.PartyFixtures
 
-  @create_attrs %{title: "some title", singer: "some singer"}
-  @update_attrs %{title: "some updated title", singer: "some updated singer"}
+  @create_attrs %{title: "some title", singer: "some singer", artist: "some artist"}
+  @update_attrs %{title: "some updated title", singer: "some updated singer", artist: "some updated artist"}
   @invalid_attrs %{title: nil, singer: nil}
   defp create_song(_) do
     song = song_fixture()


### PR DESCRIPTION
Editing songs in the queue formerly only supported changing the performer and song title. This PR allows editing the song artist.

Note: I don't know squat about phoenix or elixir. I pointed Cursor at the repo and asked it to fix this. Changes looked plausible to me, but what do I know 🤷 

I tried running tests but they seem to be in a non-passing state already.

Works on my machine:
<img width="810" height="552" alt="Screenshot 2025-12-13 at 7 48 41 PM" src="https://github.com/user-attachments/assets/9373e47c-2fce-4dd8-9df9-cf2cae6b1055" />
